### PR TITLE
Handle empty ascii responses from NXAPI

### DIFF
--- a/lib/cisco_nxapi/cisco_nxapi.rb
+++ b/lib/cisco_nxapi/cisco_nxapi.rb
@@ -219,11 +219,20 @@ module CiscoNxapi
       end
     end
 
+    # Sends a request to the NX API and returns the body of the request or
+    # handles errors that happen.
     # @raise CiscoNxapi::ConnectionRefused if NXAPI is disabled
     # @raise CiscoNxapi::HTTPUnauthorized if username/password are invalid
     # @raise CiscoNxapi::HTTPBadRequest (should never occur)
     # @raise CiscoNxapi::RequestNotSupported
     # @raise CiscoNxapi::CliError if any command is rejected as invalid
+    #
+    # @param type ["cli_show", "cli_show_ascii"] Specifies the type of command
+    #             to be executed.
+    # @param command_or_list [String, Array<String>] The command or array of
+    #                        commands which should be run.
+    # @return [Hash, Array<Hash>] output when type == "cli_show"
+    # @return [String, Array<String>] output when type == "cli_show_ascii"
     def req(type, command_or_list)
       if command_or_list.is_a?(Array)
         # NXAPI wants config lines to be separated by ' ; '
@@ -283,10 +292,20 @@ module CiscoNxapi
           handle_output(prev_cmds, cmd, o)
           prev_cmds << cmd
         end
-        output = output.each { |o| o['body'] }
+        output = output.collect do |o|
+          if type == 'cli_show_ascii' && o['body'].empty?
+            ''
+          else
+            o['body']
+          end
+        end
       else
         handle_output(prev_cmds, command, output)
-        output = output['body']
+        if type == 'cli_show_ascii' && output['body'].empty?
+          output = ''
+        else
+          output = output['body']
+        end
       end
 
       @cache_hash[type][command] = output if cache_enable?

--- a/tests/test_nxapi.rb
+++ b/tests/test_nxapi.rb
@@ -104,6 +104,11 @@ class TestNxapi < TestCase
     assert_equal(result.strip, s.split("\n")[1].strip)
   end
 
+  def test_show_ascii_empty
+    result = client.show('show hostname | include foo | exclude foo', :ascii)
+    assert_equal('', result)
+  end
+
   def test_show_structured
     result = client.show('show hostname', :structured)
     s = @device.cmd('show hostname')


### PR DESCRIPTION
If the command passed to an NX API request does not produce any return
output then the API returns an empty hash. This appears to be unexpected
for request types of cli_show_ascii, so if an empty value is received
and the type is cli_show_ascii then we should return an empty string.

The previous behavior of returning an empty hash caused unhandled
failures in the node_utils gem as well.
