### PR TITLE
Removed gem validation that caused build error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,25 @@ task spec: [:spec_no_clients,
            ]
 
 task :build do
+  system 'rm ./cisco_os_shim*.gem'
   Dir['*.gemspec'].each { |gemspec| system "gem build #{gemspec}" }
+end
+
+task :validate do
+  # Validate gem contents
+  if system('gem specification ./*nxapi*gem | grep -v homepage | grep grpc')
+    fail 'gRPC files in NXAPI gem!'
+  end
+  if system('gem specification ./*grpc*gem | grep -v homepage | grep nxapi')
+    fail 'NXAPI files in gRPC gem!'
+  end
+  if system('gem specification ./*shim-1*gem | grep -v homepage | grep /nxapi')
+    fail 'NXAPI files in core gem!'
+  end
+  if system('gem specification ./*shim-1*gem | grep -v homepage | grep /grpc')
+    fail 'gRPC files in core gem!'
+  end
+  puts 'Sanity check complete.'
 end
 
 Rake::TestTask.new do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -31,19 +31,6 @@ task spec: [:spec_no_clients,
 
 task :build do
   Dir['*.gemspec'].each { |gemspec| system "gem build #{gemspec}" }
-  # Validate gem contents
-  if system('gem specification ./*nxapi*gem | grep -v homepage | grep grpc')
-    fail 'gRPC files in NXAPI gem!'
-  end
-  if system('gem specification ./*grpc*gem | grep -v homepage | grep nxapi')
-    fail 'NXAPI files in gRPC gem!'
-  end
-  if system('gem specification ./*shim-1*gem | grep -v homepage | grep /nxapi')
-    fail 'NXAPI files in core gem!'
-  end
-  if system('gem specification ./*shim-1*gem | grep -v homepage | grep /grpc')
-    fail 'gRPC files in core gem!'
-  end
 end
 
 Rake::TestTask.new do |t|


### PR DESCRIPTION
Due to the wildcard operator in the validation code, `rake build` would fail with a cryptic message when an old cisco_os_shim gem was present in the directory.

The code seems to cause more trouble than it's worth, so I propose we remove it.

Error message:

```
~/cisco-nxapi$ rake build
WARNING:  prerelease dependency on cisco_os_shim (= 1.0.0.pre.dev) is not recommended
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: cisco_os_shim-nxapi
  Version: 1.1.0.pre.dev
  File: cisco_os_shim-nxapi-1.1.0.pre.dev.gem
WARNING:  prerelease dependency on cisco_os_shim (= 1.0.0.pre.dev) is not recommended
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: cisco_os_shim-grpc
  Version: 1.0.0.pre.dev
  File: cisco_os_shim-grpc-1.0.0.pre.dev.gem
  Successfully built RubyGem
  Name: cisco_os_shim
  Version: 1.0.0.pre.dev
  File: cisco_os_shim-1.0.0.pre.dev.gem
ERROR:  While executing gem ... (NoMethodError)
    undefined method `./cisco_os_shim-1.1.0.gem' for #<Gem::Specification:0x8e8a00 cisco_os_shim-1.0.0.pre.dev>
ERROR:  While executing gem ... (NoMethodError)
    undefined method `./cisco_os_shim-1.1.0.gem' for #<Gem::Specification:0xa1aa04 cisco_os_shim-1.0.0.pre.dev>
```
