### PR TITLE
Added rubygem version validation

### DIFF
--- a/cisco_nxapi.gemspec
+++ b/cisco_nxapi.gemspec
@@ -23,6 +23,7 @@ Designed to be used with Puppet and Chef and the cisco_node_utils gem.
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.0.0'
+  spec.required_rubygems_version = '>= 2.1.0'
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/cisco_nxapi/version.rb
+++ b/lib/cisco_nxapi/version.rb
@@ -15,4 +15,7 @@
 # Add version number to CiscoNxapi namespace
 module CiscoNxapi
   VERSION = '1.0.0'
+  gem_version = Gem::Version.new(Gem::VERSION)
+  min_gem_version = Gem::Version.new('2.1.0')
+  fail 'Required rubygems version >= 2.1.0' if gem_version < min_gem_version
 end


### PR DESCRIPTION
NXAPI follow-up commit to [node-utils #70](https://github.com/cisco/cisco-network-node-utils/pull/70) and https://github.com/cisco/cisco-network-node-utils/commit/1163b067c5eac532f74f2b83ea67941600d2a17b

Prints more helpful error message when rubygems version is out of date:

```
[!] There was an error parsing `Gemfile`: There was a RuntimeError while loading cisco_nxapi.gemspec: 
Required rubygems version >= 2.1.0 from
  /home/robgrie/cisco-nxapi/cisco_nxapi.gemspec:4
. Bundler cannot continue.

 #  from /home/robgrie/cisco-nxapi/Gemfile:4
 #  -------------------------------------------
 #  # Specify your gem's dependencies in cisco_node_nxapi.gemspec
 >  gemspec
 #  -------------------------------------------
```
