### PR TITLE
Raise LoadError unless grpc or nxapi gem missing

### DIFF
--- a/lib/cisco_os_shim.rb
+++ b/lib/cisco_os_shim.rb
@@ -21,6 +21,7 @@ extensions = ['cisco_os_shim/nxapi',
 extensions.each do |ext|
   begin
     require ext
-  rescue LoadError # rubocop:disable Lint/HandleExceptions
+  rescue LoadError => e
+    raise unless e.message =~ /#{Regexp.escape(ext)}/
   end
 end

--- a/lib/cisco_os_shim.rb
+++ b/lib/cisco_os_shim.rb
@@ -22,6 +22,7 @@ extensions.each do |ext|
   begin
     require ext
   rescue LoadError => e
+    # ignore missing cisco_os_shim-(grpc|nxapi), they're not always required
     raise unless e.message =~ /#{Regexp.escape(ext)}/
   end
 end


### PR DESCRIPTION
Raise LoadError unless missing the `cisco_os_shim-grpc` or `cisco_os_shim-nxapi` gem because in some cases those gems are not required.
## Missing all gems

```
[xr-vm_node0_RP0_CPU0:~]$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Facter: error while resolving custom fact "cisco_node_utils": cannot load such file -- cisco_node_utils
Error: Facter: error while resolving custom fact "cisco_os_shim": cannot load such file -- cisco_os_shim
Info: Caching catalog for agent-lab22-xr.cisco.com
Info: Applying configuration version '1447781604'
Error: Could not find a suitable provider for cisco_interface
Notice: Applied catalog in 0.48 seconds
```
## Missing cisco_os_shim-grpc and cisco_os_shim-nxapi

```
[xr-vm_node0_RP0_CPU0:~]$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for agent-lab22-xr.cisco.com
Error: Failed to apply catalog: Munging failed for value :nxapi in class provider: No client implementations available!
```
## Broken grpc dependency

```
[xr-vm_node0_RP0_CPU0:~]$ puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Facter: error while resolving custom fact "cisco_node_utils": libgrpc.so.0: cannot open shared object file: No such file or directory - /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/grpc-0.11.0/grpc/grpc.so
Error: Facter: error while resolving custom fact "cisco_os_shim": libgrpc.so.0: cannot open shared object file: No such file or directory - /opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/grpc-0.11.0/grpc/grpc.so
Info: Caching catalog for agent-lab22-xr.cisco.com
Info: Applying configuration version '1447782247'
Error: Could not find a suitable provider for cisco_interface
```
