### PR TITLE
Ruby ENV option used to build specific gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - lib/cisco_os_shim/grpc/ems_services.rb
     # Files we don't own
     - vendor/**/*
+    - grpc/**/*
 
 # Code complexity metrics are tracked separately for lib/ vs. tests/
 # See lib/.rubocop.yml and tests/.rubocop.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ cache: bundler
 rvm:
   - 2.2.2
   - 2.1.6
-  # grpc gem doesn't install successfully under 2.0.0:
-  # https://github.com/grpc/grpc/issues/4020
-  # - 2.0.0
+  - 2.0.0
 
 before_install:
   # sudo apt-get install libgrpc-dev doesn't work in Travis.
@@ -22,6 +20,7 @@ before_install:
   - git submodule update --init
   - make
   - sudo make install
+  - (cd src/ruby/ && gem build grpc.gemspec && gem install --local grpc*.gem)
   - cd ..
   - rm -rf grpc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - git submodule update --init
   - make
   - sudo make install
-  - (cd src/ruby/ && gem build grpc.gemspec && gem install --local grpc*.gem)
+  - (cd src/ruby/ && gem build grpc.gemspec && gem install --local -f grpc*.gem)
   - cd ..
   - rm -rf grpc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,13 @@ before_install:
   - git submodule update --init
   - make
   - sudo make install
-  - (cd src/ruby/ && gem build grpc.gemspec && gem install --local -f grpc*.gem)
-  - cd ..
+  - cd src/ruby/
+  - gem build grpc.gemspec
+  - gem install --local --force grpc-*.gem
+  - mkdir -p ../../../vendor/cache
+  - gem install --force --local grpc-*.gem
+  - cp grpc-*.gem ../../../vendor/cache
+  - cd ../../..
   - rm -rf grpc
 
 script:


### PR DESCRIPTION
`rake build GEM=[core|nxapi|grpc]` will build that target gem

This feature will support a travis fix for `feature/grpc` in cisco-network-node-utils.

Example usage:

```
~/cisco-nxapi$ rake build GEM=core
  Successfully built RubyGem
  Name: cisco_os_shim
  Version: 1.0.0.pre.dev
  File: cisco_os_shim-1.0.0.pre.dev.gem

~/cisco-nxapi$ ls *.gem
cisco_os_shim-1.0.0.pre.dev.gem
```
